### PR TITLE
feat: 쓰레기통 과적율에 따른 안내 문구 수정 (Mainmap worker)

### DIFF
--- a/src/screens/MainMap/MainMap.jsx
+++ b/src/screens/MainMap/MainMap.jsx
@@ -75,20 +75,51 @@ export const MainMap = () => {
                                 <h1 className="[font-family:'Inter',Helvetica] font-bold text-black text-md text-center tracking-[0.20px] leading-[normal]">
                                     쓰레기통 이름: {binData.binName} <br /><br />
 
-                                    쓰레기통 채워짐 정도: {binData.fillRate}%, {binData.cupWeight}kg <br />
+                                    컵통 채워짐 정도: {binData.fillRate}%, {binData.cupWeight}kg <br />
                                     물통 채워짐 정도: {binData.liquidRate}%, {binData.liquidWeight}kg <br /><br />
                                 </h1>
 
-                                {/* 쓰레기통 채워짐 정도: 80%, 4kg
-                                    물통 채워짐 정도: 60%, 3kg */}
+                                {/* 컵통 채워짐 정도: 80%, 4kg
+                                    물통 채워짐 정도: 80%, 4kg */}
 
-                                <h1 className="[font-family:'Inter',Helvetica] font-bold text-black text-sm text-center tracking-[0.20px] leading-[normal]">
-                                    쓰레기통이 거의 다 찼습니다! <br />
-                                    쓰레기통을 수거해주세요.
-                                    <br />
-                                    <br />
-                                    <br />
-                                </h1>
+                                {(() => {
+                                    const cupFull = binData.fillRate >= 80 || binData.cupWeight >= 4;
+                                    const liquidFull = binData.liquidRate >= 80 || binData.liquidWeight >= 4;
+
+                                    if (cupFull && liquidFull) {
+                                        return (
+                                            <h1 className="[font-family:'Inter',Helvetica] font-bold text-black text-sm text-center tracking-[0.20px] leading-[normal]">
+                                                쓰레기통(컵통 및 물통)이 거의 다 찼습니다! <br />
+                                                쓰레기통을 비워주세요.
+                                                <br />
+                                                <br />
+                                                <br />
+                                            </h1>
+                                        );
+                                    } else if (cupFull) {
+                                        return (
+                                            <h1 className="[font-family:'Inter',Helvetica] font-bold text-black text-sm text-center tracking-[0.20px] leading-[normal]">
+                                                컵통이 거의 다 찼습니다! <br />
+                                                컵통을 비워주세요.
+                                                <br />
+                                                <br />
+                                                <br />
+                                            </h1>
+                                        );
+                                    } else if (liquidFull) {
+                                        return (
+                                            <h1 className="[font-family:'Inter',Helvetica] font-bold text-black text-sm text-center tracking-[0.20px] leading-[normal]">
+                                                물통이 거의 다 찼습니다! <br />
+                                                물통을 비워주세요.
+                                                <br />
+                                                <br />
+                                                <br />
+                                            </h1>
+                                        );
+                                    } else {
+                                        return null;
+                                    }
+                                })()}
 
                                 <Button
                                     // onClick={() => navigate(`/dashboard`)}


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정

## 관련 이슈
Close #16 

## 개요
- 쓰레기통 과적율에 따른 안내 문구 수정 (Mainmap worker)
   쓰레기통 및 물통 채워짐 정도에 따라 문구가 동적으로 변경

## 변경 사항
- 쓰레기통 및 물통 채워짐 정도에 따라 문구가 동적으로 변경
 - GET api/bin/detail/${selectedBinId} 
    - result 내 이용 데이터
       "fillRate"
       "cupWeight"
       "liquidWeight"
       "liquidRate"
    - *쓰레기통, 물통 최대 5kg로 가정 (추후 로드셀 테스트 후 변경 가능성 有)*
      i) 컵통과 물통의 채워짐 정도가 80% 혹은 4kg일때
      문구: "쓰레기통(컵통 및 물통)이 거의 다 찼습니다!", "쓰레기통을 비워주세요."

       ii) 컵통의 채워짐 정도가 80% 혹은 4kg일때
       문구: "컵통이 거의 다 찼습니다!", "컵통을 비워주세요."

       iii) 물통의 채워짐 정도가 80% 혹은 4kg일때
       문구: "물통이 거의 다 찼습니다!", "물통을 비워주세요."
       
       iV) 그 외(과적 아닐 시) 문구 따로 추가하지 않음.

## 스크린샷
<img width="252" height="283" alt="image" src="https://github.com/user-attachments/assets/7bc3dd5c-6d92-4382-91d4-73069ad6a512" />

