### PR TITLE
fix: 실시간 그래프의 센서 값 GET api 업데이트

### DIFF
--- a/src/screens/Dashboard/sections/LiveSensorGraph/LiveSensorGraph.jsx
+++ b/src/screens/Dashboard/sections/LiveSensorGraph/LiveSensorGraph.jsx
@@ -83,10 +83,11 @@ export const LiveSensorGraph = ({ binId }) => {
                 if (!binId) return;
 
                 try {
-                    const response = await axios.get(`/bin/${binId}/sensor/${apiEndpoint}/history/live`, {
-                        params: { limit: MAX_POINTS },
+                    // 초기 데이터 최근 13개 로드
+                    const response = await axios.get(`http://localhost:8080/api/bin/${binId}/sensor/${apiEndpoint}/history/live`, {
+                        params: { limit: 13 },
                     });
-                    // 최신이 뒤에 오도록 정렬 가정
+                    // 백엔드에서 배열로 반환, 최신이 뒤에 오도록 처리
                     const history = response.data.map((d) => ({
                         label: new Date(d.timestamp).toLocaleTimeString("ko-KR", {
                             hour: "2-digit",
@@ -96,6 +97,7 @@ export const LiveSensorGraph = ({ binId }) => {
                         value: d.value,
                     }));
                     setData(history);
+                    console.log("📊 초기 데이터 로드 완료:", history.length, "개");
                 } catch (e) {
                     console.error("initial sensor history error", e);
                 }
@@ -138,14 +140,22 @@ export const LiveSensorGraph = ({ binId }) => {
                     if (!binId) return;
 
                     try {
-                        const response = await axios.get(`/bin/${binId}/sensor/${apiEndpoint}/history/live`);
-                        const { timestamp, value } = response.data;
+                        // limit=1로 최신 데이터 1개만 요청
+                        const response = await axios.get(`http://localhost:8080/api/bin/${binId}/sensor/${apiEndpoint}/history/live`, {
+                            params: { limit: 1 },
+                        });
+                        // 배열로 반환되므로 첫 번째 요소 사용
+                        const latestData = response.data[0];
+                        if (!latestData) return;
 
+                        const { timestamp, value } = latestData;
                         const label = new Date(timestamp).toLocaleTimeString("ko-KR", {
                             hour: "2-digit",
                             minute: "2-digit",
                             second: "2-digit",
                         });
+
+                        console.log("📈 실시간 데이터 추가:", { label, value });
 
                         setData((prev) => {
                             const next = [...prev, { label, value }];


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정

## 관련 이슈
Close #35

## 개요
- 실시간 그래프의 센서 값 GET api 업데이트 (백 api 요청 응답에 따라 수정)


## 변경 사항
- 초기 그래프 모양 그려놓기
  - 그래프 화면 기준 최근 데이터 13개(x축 시간대 개수)를 가져옴
  
     curl -X 'GET' \
  'http://localhost:8080/api/bin/1/sensor/ultrasonic/history/live?limit=13' \
  -H 'accept: */*'
- 실시간 센서값 가져오기
  -  가장 최근 데이터 하나를 가져옴
  curl -X 'GET' \
  'http://localhost:8080/api/bin/1/sensor/ultrasonic/history/live?limit=1' \
  -H 'accept: */*'

## 스크린샷
### 실시간 그래프
<img width="936" height="408" alt="image" src="https://github.com/user-attachments/assets/5480bd63-9c84-4d28-b721-3058dde06b34" />
